### PR TITLE
chore: add pypi classifiers to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,24 @@ authors = [
 license = "MIT"
 requires-python = ">=3.6"
 keywords = ["redis", "aioredis", "asyncio", "fastapi", "starlette", "cache"]
-# classifiers = [] # https://pypi.org/classifiers/
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Framework :: FastAPI"
+]
 dependencies = ["aioredis==1.3.1"]
 
 [dependency-groups]


### PR DESCRIPTION
Fixes #1

Add PyPI classifiers to `pyproject.toml`.

* Uncomment the `classifiers` section.
* Add appropriate PyPI classifiers including development status, intended audience, license, programming languages, topics, and framework.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/leynier/fastapi-cache-plus/pull/2?shareId=12a9ff43-2eb5-463a-81a8-1a74bd13d32d).